### PR TITLE
Changed Interrupt disabling from CLI/STI to enable/disable IRQ.

### DIFF
--- a/student-distrib/i8259.c
+++ b/student-distrib/i8259.c
@@ -155,7 +155,7 @@ send_eoi(uint32_t irq_num)
     uint8_t port;
     uint8_t value;
 
-     // Check if the irq_num belongs to master or slave
+     /* Check if the irq_num belongs to master or slave */
     if(irq_num < PIC_MAX_PINS)
         port = MASTER_8259_PORT;
     else
@@ -185,10 +185,9 @@ send_eoi(uint32_t irq_num)
 void
 pit_interrupt_handler(void)
 {
-    int flags;
-    cli_and_save(flags);
-    outb(UNIMPLEMENTED_ACK, MASTER_8259_PORT);
-    restore_flags(flags);
+    disable_irq(PIT_IRQ);
+    send_eoi(PIT_IRQ);
+    enable_irq(PIT_IRQ);
 }
 
 
@@ -204,11 +203,8 @@ pit_interrupt_handler(void)
 void
 pic_master_irq_handler(void)
 {
-    int flags;
-    cli_and_save(flags);
     printf("Unimplemented master PIC IRQ!\n");
     outb(UNIMPLEMENTED_ACK, MASTER_8259_PORT);
-    restore_flags(flags);
 }
 
 
@@ -227,5 +223,4 @@ pic_slave_irq_handler(void)
     printf("Unimplemented slave PIC IRQ!\n");
     outb(UNIMPLEMENTED_ACK, MASTER_8259_PORT);
     outb(UNIMPLEMENTED_ACK, SLAVE_8259_PORT);
-    sti();
 }

--- a/student-distrib/keyboard.c
+++ b/student-distrib/keyboard.c
@@ -90,8 +90,7 @@ keyboard_init()
 void
 keyboard_interrupt_handler()
 {
-    int flags;
-    cli_and_save(flags);
+    disable_irq(KEYBOARD_IRQ);
 
     uint8_t c = inb(KEYBOARD_PORT);
     io_wait();
@@ -118,5 +117,5 @@ keyboard_interrupt_handler()
     }
 
     send_eoi(KEYBOARD_IRQ);
-    restore_flags(flags);
+    enable_irq(KEYBOARD_IRQ);
 }

--- a/student-distrib/rtc.c
+++ b/student-distrib/rtc.c
@@ -59,8 +59,7 @@ rtc_init(void)
 void
 rtc_interrupt_handler(void)
 {
-    unsigned int flags;
-    cli_and_save(flags);
+    disable_irq(RTC_IRQ);
 
     /* test_interrupts(); */
 
@@ -69,5 +68,5 @@ rtc_interrupt_handler(void)
     inb(RTC_PORT2);
 
     send_eoi(RTC_IRQ);
-    restore_flags(flags);
+    enable_irq(RTC_IRQ);
 }


### PR DESCRIPTION
We do not want to disable ALL interrupts when handling an interrupt for one IRQ. Instead, we only disable that particular IRQ, handle the interrupt, and reenable it.

This was tested on my computer, so someone else in the ECE Lab should also test it before submission.
